### PR TITLE
GMS1 Decompile-Script : Change all event id to 603 to resolve compile error

### DIFF
--- a/UndertaleModTool/Decompiling_Scripts/--- GMS1 Decompiling ---/Ultimate_GMS1_Decompiler.csx
+++ b/UndertaleModTool/Decompiling_Scripts/--- GMS1 Decompiling ---/Ultimate_GMS1_Decompiler.csx
@@ -291,6 +291,7 @@ string decompileCode(UndertaleCode codeId)
 {
     string code = codeId != null ? new Underanalyzer.Decompiler.DecompileContext(decompileContext, codeId, decompilerSettings).DecompileToString() : "";
     // return code as string to be copied over to .gml file or .gmx asset
+    
     return code;
 }
 #endregion
@@ -537,7 +538,7 @@ void ExportGameObject(UndertaleGameObject gameObject)
                 {
                     actionNode.Add(
                         new XElement("libid", k.LibID.ToString()),
-                        new XElement("id", k.ID.ToString()),
+                        new XElement("id", "603"),
                         new XElement("kind", k.Kind.ToString()),
                         new XElement("userelative", BoolToString(k.UseRelative)),
                         new XElement("isquestion", BoolToString(k.IsQuestion)),
@@ -908,7 +909,7 @@ void ExportTimeline(UndertaleTimeline timeline)
             entryNode.Element("event").Add(
                 new XElement("action",
                     new XElement("libid", j.LibID.ToString()),
-                    new XElement("id", j.ID.ToString()),
+                    new XElement("id", "603"),
                     new XElement("kind", j.Kind.ToString()),
                     new XElement("userelative", BoolToString(j.UseRelative)),
                     new XElement("isquestion", BoolToString(j.IsQuestion)),


### PR DESCRIPTION
As we know, all events in GameMaker Studio (GMS) are ultimately compiled into executable GML code, regardless of whether they were created using drag-and-drop actions or direct scripting. However, the current decompiler script seems unaware of this behavior.

When updating the project format, this mismatch leads to numerous compilation errors, as shown in the example below:

![03ecd4e3e3bb562aa772d482eb8cbd02](https://github.com/user-attachments/assets/ae46890b-a753-43b7-a356-48e3b1899066)

To address this issue at its root, my solution is to convert all event actions to use event ID `603` (code execution). This approach ensures that all logic is interpreted as raw GML code, eliminating ambiguity and preventing these frustrating compile-time errors.

In my opinion, this is the simplest and most effective way to deal with the problem.
